### PR TITLE
Visualização da duração de etapas no fluxo

### DIFF
--- a/src/components/Flow/index.tsx
+++ b/src/components/Flow/index.tsx
@@ -21,6 +21,7 @@ interface FlowProps {
   currentStage?: string | number | undefined;
   effectiveDate?: string | undefined;
   isFetching?: boolean;
+  showStagesDuration?: boolean;
 }
 
 export function Flow({
@@ -32,6 +33,7 @@ export function Flow({
   currentStage = undefined,
   effectiveDate = undefined,
   isFetching = false,
+  showStagesDuration = false,
 }: FlowProps) {
   const startDate = effectiveDate ? new Date(effectiveDate) : null;
   const sortedStages = useMemo(() => {
@@ -85,7 +87,11 @@ export function Flow({
 
   const nodes = sortedStages.map((item, index) => {
     const deadline = getStageDeadline(item, index);
-
+    const stageLabel = `${_.startCase(item.name)}, ${
+      showStagesDuration
+        ? ` (${item.duration} dia${item.duration > 1 ? "s" : ""})`
+        : ""
+    }`;
     return {
       id: `${item.idStage}`,
       position: {
@@ -93,14 +99,16 @@ export function Flow({
         y: 30 + index * (currentStage ? 125 : 100),
       },
       data: {
-        label: deadline ? (
+        label: (
           <>
-            {_.startCase(item.name)}
-            <br />
-            Vencimento: {deadline}
+            {stageLabel}
+            {deadline ? (
+              <>
+                {" "}
+                <br /> {`Vencimento: ${deadline}`}{" "}
+              </>
+            ) : null}
           </>
-        ) : (
-          _.startCase(item.name)
         ),
       },
       style: {

--- a/src/pages/Flows/CreationModal/index.tsx
+++ b/src/pages/Flows/CreationModal/index.tsx
@@ -159,7 +159,7 @@ export function CreationModal({
                 }
                 options={stagesData?.value?.map((item: Stage) => {
                   return {
-                    label: item.name,
+                    label: `${item.name}, (${item.duration} dia${item.duration > 1 ? "s" : ""})`,
                     value: item.idStage,
                   };
                 })}

--- a/src/pages/Flows/CreationModal/index.tsx
+++ b/src/pages/Flows/CreationModal/index.tsx
@@ -159,7 +159,9 @@ export function CreationModal({
                 }
                 options={stagesData?.value?.map((item: Stage) => {
                   return {
-                    label: `${item.name}, (${item.duration} dia${item.duration > 1 ? "s" : ""})`,
+                    label: `${item.name}, (${item.duration} dia${
+                      item.duration > 1 ? "s" : ""
+                    })`,
                     value: item.idStage,
                   };
                 })}
@@ -194,7 +196,11 @@ export function CreationModal({
                 }}
               />
             ) : null}
-            <Flow stages={selectedStages} sequences={sequences} />
+            <Flow
+              stages={selectedStages}
+              sequences={sequences}
+              showStagesDuration
+            />
           </ModalBody>
           <ModalFooter gap="2">
             <Button variant="ghost" onClick={onClose} size="sm">

--- a/src/pages/Flows/EditionModal/index.tsx
+++ b/src/pages/Flows/EditionModal/index.tsx
@@ -121,9 +121,10 @@ export function EditionModal({
 
   function stageToSelectOption(value: Stage[]): SelectOption[] {
     return value?.map((item: Stage) => {
-      
       return {
-        label: `${item.name}, (${item.duration} dia${item.duration > 1 ? "s" : ""})`,
+        label: `${item.name}, (${item.duration} dia${
+          item.duration > 1 ? "s" : ""
+        })`,
         value: item.idStage,
       };
     });
@@ -198,7 +199,11 @@ export function EditionModal({
                 }}
               />
             ) : null}
-            <Flow stages={selectedStages} sequences={sequences} />
+            <Flow
+              stages={selectedStages}
+              sequences={sequences}
+              showStagesDuration
+            />
           </ModalBody>
           <ModalFooter gap="2">
             <Button variant="ghost" onClick={onClose} size="sm">

--- a/src/pages/Flows/EditionModal/index.tsx
+++ b/src/pages/Flows/EditionModal/index.tsx
@@ -121,8 +121,9 @@ export function EditionModal({
 
   function stageToSelectOption(value: Stage[]): SelectOption[] {
     return value?.map((item: Stage) => {
+      
       return {
-        label: item.name,
+        label: `${item.name}, (${item.duration} dia${item.duration > 1 ? "s" : ""})`,
         value: item.idStage,
       };
     });


### PR DESCRIPTION
## Issue

Closes fga-eps-mds/2023-1-CAPJu-Doc#66

## Descriçao

Alteração no campo "Etapas" nas modais de Creation/Edition Flow para aparecer a quantidade de dias e uma outra para a lable da sequencia dos componentes para aparecer a quantidade de dias no React Flow

## Revisão 
- [ ] Deve ser possível visualizar quantos dias cada etapa vai durar naquele fluxo

## Pre-merge checklist 

- [ ] O Pull Request refere-se a um único assunto, um título claro e uma descrição em frases gramaticalmente corretas e completas.
- [ ] A ramificação está atualizada com a branch Develop.
- [ ] Os commits atendem o padrão especificado na política de contribuição.